### PR TITLE
Fix project BD/RD permission validation when source type is Azure DevOps

### DIFF
--- a/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-vsts-source/configure-vsts-source.component.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/step-configure/configure-vsts-source/configure-vsts-source.component.ts
@@ -140,7 +140,7 @@ export class ConfigureVstsSourceComponent implements OnDestroy {
           this._vstsRepositories.map(repo => {
             return {
               displayLabel: `${repo.project.name} (${repo.project.id})`,
-              value: repo.project.id,
+              value: repo.project.name,
             };
           }),
           'value'
@@ -206,12 +206,14 @@ export class ConfigureVstsSourceComponent implements OnDestroy {
 
   projectChanged(selectedProject: DropDownElement<string>) {
     this.repositoryList = uniqBy(
-      this._vstsRepositories.filter(r => r.project.id === selectedProject.value).map(repo => {
-        return {
-          displayLabel: repo.name,
-          value: repo.remoteUrl,
-        };
-      }),
+      this._vstsRepositories
+        .filter(r => r.project.name === selectedProject.value)
+        .map(repo => {
+          return {
+            displayLabel: repo.name,
+            value: repo.remoteUrl,
+          };
+        }),
       'value'
     );
     this.selectedRepo = '';


### PR DESCRIPTION
Fixes a part of https://github.com/Azure/azure-functions-ux/issues/3846

The code to do validation for BD and RD permission check is already there, but there was a bug in a way this check was consumed when source is Azure DevOps repo.