### PR TITLE
Add validation for agent queue permission

### DIFF
--- a/client/src/app/shared/models/constants.ts
+++ b/client/src/app/shared/models/constants.ts
@@ -490,6 +490,10 @@ export class DeploymentCenterConstants {
   public static readonly releaseSecurityNameSpace = 'C788C23E-1B46-4162-8F5E-D7585343B5DE';
   public static readonly editReleaseDefinitionPermission = 2;
 
+  // Agent queues
+  public static readonly agentQueueNames = ['Hosted VS2017', 'Hosted Ubuntu 1604', 'Default'];
+  public static readonly queueActionFilter = 16; // "Use"
+
   public static readonly EmptyGuid = '00000000-0000-0000-0000-000000000000';
 }
 

--- a/client/src/app/shared/models/portal-resources.ts
+++ b/client/src/app/shared/models/portal-resources.ts
@@ -1139,6 +1139,7 @@ export class PortalResources {
   public static FTPLabel = 'FTPLabel';
   public static validating = 'validating';
   public static vstsReleaseBuildPermissions = 'vstsReleaseBuildPermissions';
+  public static vstsAgentQueuePermissions = 'vstsAgentQueuePermissions';
   public static vstsNameUnavailable = 'vstsNameUnavailable';
   public static FTPBoth = 'FTPBoth';
   public static FTPSOnly = 'FTPSOnly';

--- a/client/src/app/site/deployment-center/deployment-center-setup/validators/vsts-validators.ts
+++ b/client/src/app/site/deployment-center/deployment-center-setup/validators/vsts-validators.ts
@@ -82,6 +82,15 @@ export class VstsValidators {
                         }/${DeploymentCenterConstants.editReleaseDefinitionPermission}?tokens=${currentProject.id}`,
                         true,
                         callHeaders
+                      ),
+                      _cacheService.get(
+                        `https://${vstsAccountValue}.visualstudio.com/${
+                          currentProject.id
+                        }/_apis/distributedtask/queues?queueNames=${DeploymentCenterConstants.agentQueueNames.join(',')}&actionFilter=${
+                          DeploymentCenterConstants.queueActionFilter
+                        }&api-version=5.1-preview.1`,
+                        true,
+                        callHeaders
                       )
                     );
                   });
@@ -89,12 +98,19 @@ export class VstsValidators {
               return Observable.of(null);
             })
             .map(results => {
-              if (results && results.length === 2) {
+              if (results && results.length === 3) {
                 const buildPermissions = results[0] ? results[0].json().value[0] : true;
                 const releasePermissions = results[1] ? results[1].json().value[0] : true;
+                const queuePermissions = results[2] && results[2].json().count > 0 ? true : false;
                 if (!buildPermissions || !releasePermissions) {
                   return {
                     invalidPermissions: _translateService.instant(PortalResources.vstsReleaseBuildPermissions),
+                  };
+                }
+
+                if (!queuePermissions) {
+                  return {
+                    invalidPermissions: _translateService.instant(PortalResources.vstsAgentQueuePermissions),
                   };
                 }
               }

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3548,7 +3548,10 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>Validating...</value>
   </data>
   <data name="vstsReleaseBuildPermissions" xml:space="preserve">
-    <value>You do not have permissions to create a Build pipeline or a Release pipeline on this project. Contact your project administrator</value>
+    <value>You do not have permissions to create a Build pipeline or a Release pipeline on this project. Contact your project administrator or choose a different project</value>
+  </data>
+  <data name="vstsAgentQueuePermissions" xml:space="preserve">
+    <value>You do not have permissions to use at least one of the available agent pools in this project . Contact your project administrator or choose a different project</value>
   </data>
   <data name="vstsNameUnavailable" xml:space="preserve">
     <value>The organization name supplied is not valid. Please supply another organization name.</value>

--- a/server/Resources/Resources.resx
+++ b/server/Resources/Resources.resx
@@ -3551,7 +3551,7 @@ Set to "External URL" to use an API definition that is hosted elsewhere.</value>
     <value>You do not have permissions to create a Build pipeline or a Release pipeline on this project. Contact your project administrator or choose a different project</value>
   </data>
   <data name="vstsAgentQueuePermissions" xml:space="preserve">
-    <value>You do not have permissions to use at least one of the available agent pools in this project . Contact your project administrator or choose a different project</value>
+    <value>You do not have permissions to use at any of the available agent pools in this project . Contact your project administrator or choose a different project</value>
   </data>
   <data name="vstsNameUnavailable" xml:space="preserve">
     <value>The organization name supplied is not valid. Please supply another organization name.</value>


### PR DESCRIPTION
Fixes part of Azure#3846

I have not added validation for service endpoint permission as it can fail if the permissions are not initialized. Also the count of such failures is low.